### PR TITLE
Order by relationship issue

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -1918,10 +1918,15 @@ class MY_Model extends CI_Model
 
     private function _build_sorter($data, $field, $order_by, $sort_by = 'DESC')
     {
-        usort($data, function($a, $b) use ($field, $order_by, $sort_by) {
-            $array_a = $this->object_to_array($a[$field]);
-            $array_b = $this->object_to_array($b[$field]);
-            return strtoupper($sort_by) ==  "DESC" ? ((isset($array_a[$order_by]) && isset($array_b[$order_by])) ? ($array_a[$order_by] < $array_b[$order_by]) : -1) : ((isset($array_a[$order_by]) && isset($array_b[$order_by])) ? ($array_a[$order_by] > $array_b[$order_by]) : -1);
+        $sort_array = explode('_',$sort_by);
+        $sort_by = $sort_array[0];
+        $null_top = (isset($sort_array[1]) && strtoupper($sort_array[1]) == 'NULL' && isset($sort_array[2]) && strtoupper($sort_array[2])  == 'TOP')? -1 :+1;
+        usort($data, function($a, $b) use ($field, $order_by, $sort_by,$null_top) {
+            $array_a = isset($a[$field]) ? $this->object_to_array($a[$field]) : NULL;
+            $array_b = isset($b[$field]) ? $this->object_to_array($b[$field]) : NULL;
+            return strtoupper($sort_by) ==  "DESC" ?
+                ((isset($array_a[$order_by]) && isset($array_b[$order_by])) ? ($array_a[$order_by] < $array_b[$order_by]) : (!isset($array_b) ? $null_top*-1: -1))
+                : ((isset($array_a[$order_by]) && isset($array_b[$order_by])) ? ($array_a[$order_by] > $array_b[$order_by]) : (!isset($array_a)? $null_top: -1));
         });
 
         return $data;

--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -1918,9 +1918,7 @@ class MY_Model extends CI_Model
 
     private function _build_sorter($data, $field, $order_by, $sort_by = 'DESC')
     {
-        $sort_array = explode('_',$sort_by);
-        $sort_by = $sort_array[0];
-        usort($data, function($a, $b) use ($field, $order_by, $sort_by,$null_top) {
+        usort($data, function($a, $b) use ($field, $order_by, $sort_by) {
             $array_a = isset($a[$field]) ? $this->object_to_array($a[$field]) : NULL;
             $array_b = isset($b[$field]) ? $this->object_to_array($b[$field]) : NULL;
             return strtoupper($sort_by) ==  "DESC" ?

--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -1920,13 +1920,12 @@ class MY_Model extends CI_Model
     {
         $sort_array = explode('_',$sort_by);
         $sort_by = $sort_array[0];
-        $null_top = (isset($sort_array[1]) && strtoupper($sort_array[1]) == 'NULL' && isset($sort_array[2]) && strtoupper($sort_array[2])  == 'TOP')? -1 :+1;
         usort($data, function($a, $b) use ($field, $order_by, $sort_by,$null_top) {
             $array_a = isset($a[$field]) ? $this->object_to_array($a[$field]) : NULL;
             $array_b = isset($b[$field]) ? $this->object_to_array($b[$field]) : NULL;
             return strtoupper($sort_by) ==  "DESC" ?
-                ((isset($array_a[$order_by]) && isset($array_b[$order_by])) ? ($array_a[$order_by] < $array_b[$order_by]) : (!isset($array_b) ? $null_top*-1: -1))
-                : ((isset($array_a[$order_by]) && isset($array_b[$order_by])) ? ($array_a[$order_by] > $array_b[$order_by]) : (!isset($array_a)? $null_top: -1));
+                ((isset($array_a[$order_by]) && isset($array_b[$order_by])) ? ($array_a[$order_by] < $array_b[$order_by]) : (!isset($array_a) ? 1 : -1))
+                : ((isset($array_a[$order_by]) && isset($array_b[$order_by])) ? ($array_a[$order_by] > $array_b[$order_by]) : (!isset($array_b) ? 1: -1));
         });
 
         return $data;


### PR DESCRIPTION
Fix undefined index in order_by inside relationship #171. 

When the relationship is empty set it to NULL to prevent object_to_array conversion error. 
Row with empty relationship will be place at the bottom of the list regardless of the direction (ASC or DESC) 
This can be override to place empty relationship at the top  by appending  _NULL_TOP to the direction (asc_null_top or desc_null_top)

I have tested with a limited set of data. This should be tested with a larger data set
